### PR TITLE
Add .NET SDK 2

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -26,7 +26,7 @@ RUN dpkg -i packages-microsoft-prod.deb
 RUN apt-key adv --keyserver hkp://keyserver.ubuntu.com:80 --recv-keys 3FA7E0328081BFF6A14DA29AA6A19B38D3D831EF
 RUN echo "deb https://download.mono-project.com/repo/ubuntu stable-focal main" | tee /etc/apt/sources.list.d/mono-official-stable.list
 RUN apt update
-RUN apt install -yq apt-transport-https dotnet-sdk-3.1 nuget msbuild mono-devel
+RUN apt install -yq apt-transport-https dotnet-sdk-2.1 dotnet-sdk-3.1 nuget msbuild mono-devel
 
 # Install Java, Maven and Gradle
 RUN curl -s "https://get.sdkman.io" | bash

--- a/README.md
+++ b/README.md
@@ -8,10 +8,13 @@ JFrog Ecosystem integration environment is a Docker image containing all the too
 ## Using the Docker Image
 
 This Docker image can be pulled from `releases.jfrog.io` by running the following command:
-````
+
+```
 docker pull releases-docker.jfrog.io/jfrog-ecosystem-integration-env:<tag>
-````
+```
+
 Running the docker image:
+
 ```
 docker run -it releases-docker.jfrog.io/jfrog-ecosystem-integration-env
 ```
@@ -22,19 +25,19 @@ The image is using `apt` and `sdkman` to download the build tools. Note: In the 
 
 Operating system: Ubuntu 20.04.
 
-|  Tool   | Current version |  Package name  |                      Source                      |
-| :-----: | :-------------: | :------------: | :----------------------------------------------: |
-|  .NET   |      3.1.x      | dotnet-sdk-3.1 | https://packages.microsoft.com/ubuntu/20.04/prod |
-|  cURL   |     7.68.x      |      curl      |                  Ubuntu archive                  |
-|   Go    |     1.14.x      |  golang-1.14   |                  Ubuntu archive                  |
-| Gradle  |      6.5.x      |     gradle     |          https://sdkman.io/sdks#gradle           |
-|   JDK   |     11.0.x      | 11.0.7.hs-adpt |       https://sdkman.io/jdks#AdoptOpenJDK        |
-|   jq    |      1.6.x      |       jq       |                  Ubuntu archive                  |
-| MSBuild |    16.5.x-ci    |    msbuild     |  https://download.mono-project.com/repo/ubuntu   |
-| NodeJS  |      10.x       |     nodejs     |                  Ubuntu archive                  |
-|  Maven  |      3.6.x      |     maven      |           https://sdkman.io/sdks#maven           |
-|  Mono   |     6.8.0.x     |   mono-devel   |  https://download.mono-project.com/repo/ubuntu   |
-|   npm   |     6.14.x      |      npm       |                  Ubuntu archive                  |
-|  NuGet  |     5.5.0.x     |     nuget      |  https://download.mono-project.com/repo/ubuntu   |
-|   Pip   |     20.0.x      |  python3-pip   |                  Ubuntu archive                  |
-| Python  |      3.8.x      |  python3-pip   |                  Ubuntu archive                  |
+|  Tool   | Current version |    Package name    |                      Source                      |
+| :-----: | :-------------: | :----------------: | :----------------------------------------------: |
+|  .NET   |  2.1.x, 3.1.x   | dotnet-sdk-2.1,3.1 | https://packages.microsoft.com/ubuntu/20.04/prod |
+|  cURL   |     7.68.x      |        curl        |                  Ubuntu archive                  |
+|   Go    |     1.14.x      |    golang-1.14     |                  Ubuntu archive                  |
+| Gradle  |      6.5.x      |       gradle       |          https://sdkman.io/sdks#gradle           |
+|   JDK   |     11.0.x      |   11.0.7.hs-adpt   |       https://sdkman.io/jdks#AdoptOpenJDK        |
+|   jq    |      1.6.x      |         jq         |                  Ubuntu archive                  |
+| MSBuild |    16.5.x-ci    |      msbuild       |  https://download.mono-project.com/repo/ubuntu   |
+| NodeJS  |      10.x       |       nodejs       |                  Ubuntu archive                  |
+|  Maven  |      3.6.x      |       maven        |           https://sdkman.io/sdks#maven           |
+|  Mono   |     6.8.0.x     |     mono-devel     |  https://download.mono-project.com/repo/ubuntu   |
+|   npm   |     6.14.x      |        npm         |                  Ubuntu archive                  |
+|  NuGet  |     5.5.0.x     |       nuget        |  https://download.mono-project.com/repo/ubuntu   |
+|   Pip   |     20.0.x      |    python3-pip     |                  Ubuntu archive                  |
+| Python  |      3.8.x      |    python3-pip     |                  Ubuntu archive                  |


### PR DESCRIPTION
Add .NET SDK 2 to allow running JFrog CLI NuGet tests