### PR TITLE
Add /root workdir

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,7 @@
 FROM ubuntu:20.04
 
 SHELL ["/bin/bash", "-c"]
+WORKDIR /root
 
 # Environment variables
 ENV HOME /root
@@ -26,7 +27,7 @@ RUN apt update && apt install -yq golang-go
 
 # Install .NET & NuGet
 RUN curl -sL https://packages.microsoft.com/config/ubuntu/20.04/packages-microsoft-prod.deb -o packages-microsoft-prod.deb
-RUN dpkg -i packages-microsoft-prod.deb
+RUN dpkg -i packages-microsoft-prod.deb && rm packages-microsoft-prod.deb
 RUN apt-key adv --keyserver hkp://keyserver.ubuntu.com:80 --recv-keys 3FA7E0328081BFF6A14DA29AA6A19B38D3D831EF
 RUN echo "deb https://download.mono-project.com/repo/ubuntu stable-focal main" | tee /etc/apt/sources.list.d/mono-official-stable.list
 RUN apt update


### PR DESCRIPTION
* When running `docker run -it releases-docker.jfrog.io/jfrog-ecosystem-integration-env` the working dir will be `/root` and not `/`.
* Remove packages-microsoft-prod.deb file.