### PR TITLE
Fix JDK installation

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -42,7 +42,7 @@ RUN apt install -yq apt-transport-https dotnet-sdk-2.1 dotnet-sdk-3.1 nuget msbu
 
 # Install Java, Maven and Gradle
 RUN curl -s "https://get.sdkman.io" | bash
-RUN source "/home/frogger/.sdkman/bin/sdkman-init.sh" && sdk install java `sdk list java | grep -E "11.*hs-adpt" | head -1 | awk '{print $NF}'` && java -version \
+RUN source "/home/frogger/.sdkman/bin/sdkman-init.sh" && sdk install java `sdk list java | grep -E "11.*tem" | head -1 | awk '{print $NF}'` && java -version \
     && sdk install maven \
     && sdk install gradle \
     && sdk flush archives

--- a/README.md
+++ b/README.md
@@ -31,7 +31,7 @@ Operating system: Ubuntu 20.04.
 |  cURL   |     7.68.x      |        curl        |                  Ubuntu archive                  |
 |   Go    |     1.18.x      |     golang-go      |              https://golang.org/dl               |
 | Gradle  |      7.2.x      |       gradle       |          https://sdkman.io/sdks#gradle           |
-|   JDK   |     11.0.x      |   11.0.7.hs-adpt   |       https://sdkman.io/jdks#AdoptOpenJDK        |
+|   JDK   |     11.0.x      |        tem         |            https://sdkman.io/jdks#tem            |
 |   jq    |      1.6.x      |         jq         |                  Ubuntu archive                  |
 |  Maven  |      3.8.x      |       maven        |           https://sdkman.io/sdks#maven           |
 |  Mono   |    6.12.0.x     |     mono-devel     |  https://download.mono-project.com/repo/ubuntu   |


### PR DESCRIPTION
AdoptOpenJDK no longer exists in SDKMAN. It is deprecated and replaced by Temurin.
As a result, SDKMAN fallback to the default Temurin 17, instead of 11. See https://github.com/jfrog/jfrog-ecosystem-integration-env/runs/7537737362?check_suite_focus=true#step:5:55

This PR replaces the not-existed AdoptOpenJDK by Temurin - See https://sdkman.io/jdks#tem