### PR TITLE
Update Dockerfile to install libpq-dev

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -63,6 +63,9 @@ RUN echo "deb [arch=$(dpkg --print-architecture) signed-by=/usr/share/keyrings/d
 RUN apt update
 RUN apt install -y docker-ce docker-ce-cli containerd.io
 
+# Install PostgreSQL library
+RUN apt install -y libpq-dev
+
 # Clean up
 RUN apt autoremove
 RUN apt clean


### PR DESCRIPTION
When psycopg2 is installed by pip, pg_config is required. It is contained in libpq-dev.