### PR TITLE
Slim image, patch pip/setuptools, drop dockerd

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -15,60 +15,68 @@ ENV M2_HOME /home/frogger/.sdkman/candidates/maven/current
 ARG APT_KEY_DONT_WARN_ON_DANGEROUS_USAGE=true
 ARG DEBIAN_FRONTEND=noninteractive
 
-# Install prerequisites
-RUN apt update && apt -yq upgrade
-RUN apt install -yq zip unzip curl git uuid jq gettext python3-pip python3-venv apt-utils gnupg lsb-release
+# OS prerequisites + CVE patches. Single layer with apt cache stripped at the end
+# so the cache doesn't bloat the image. --no-install-recommends drops doc/locale extras.
+RUN apt-get update && apt-get -yq upgrade \
+    && apt-get install -yq --no-install-recommends \
+         apt-transport-https apt-utils ca-certificates curl git gettext gnupg \
+         jq lsb-release python3-pip python3-venv unzip uuid zip \
+    && rm -rf /var/lib/apt/lists/*
 
-# Install npm
-RUN curl -sL https://deb.nodesource.com/setup_18.x | bash -
-RUN apt install -yq nodejs
+# Node.js + Yarn + python symlinks. NodeSource repo is set up then nodejs installed
+# in the same layer; npm cache is cleaned to keep the layer minimal.
+RUN curl -sL https://deb.nodesource.com/setup_18.x | bash - \
+    && apt-get install -yq --no-install-recommends nodejs \
+    && npm install -g --no-fund yarn \
+    && npm cache clean --force \
+    && rm -rf /root/.npm /var/lib/apt/lists/* \
+    && ln -sf /usr/bin/pip3 /usr/bin/pip \
+    && ln -s /usr/bin/python3 /usr/bin/python
 
-# Install Yarn
-RUN npm install -g yarn
-
-# Configure Python
-RUN ln -sf /usr/bin/pip3 /usr/bin/pip
-RUN ln -s /usr/bin/python3 /usr/bin/python
-
-# Install Pipenv and Poetry
-RUN pip install pipenv poetry --quiet
-# Override transitive pin from pipenv/poetry that pulled vulnerable cryptography 45.0.2
-RUN pip install --upgrade 'cryptography>=46.0.3' --quiet
+# Pipenv + Poetry. Then explicitly upgrade pip / setuptools / cryptography to
+# versions past the known-vulnerable ones (CVE-2025-8869 in pip < 25.3,
+# CVE-2025-47273 in setuptools < 78.1.1, multiple CVEs in cryptography < 46.0.3).
+# --no-cache-dir avoids baking the wheel cache into the layer.
+RUN pip install --no-cache-dir --quiet pipenv poetry \
+    && pip install --no-cache-dir --quiet --upgrade \
+         'pip>=25.3' 'setuptools>=78.1.1' 'cryptography>=46.0.3'
 
 # Install Go
 RUN curl -fL https://golang.org/dl/go1.26.3.linux-amd64.tar.gz | tar -zxC /usr/local
 
-# Install .NET & NuGet
-RUN curl -sL https://packages.microsoft.com/config/ubuntu/22.04/packages-microsoft-prod.deb -o packages-microsoft-prod.deb
-RUN dpkg -i packages-microsoft-prod.deb && rm packages-microsoft-prod.deb
-# Mono apt source — fetch the ASCII-armored key from the same host that serves the apt repo
-# (CI allows download.mono-project.com but blocks keyserver.ubuntu.com), then dearmor to the
-# binary OpenPGP format that signed-by= requires.
-RUN curl -fsSL https://download.mono-project.com/repo/xamarin.gpg \
-      | gpg --dearmor -o /usr/share/keyrings/mono-archive-keyring.gpg
-RUN echo "deb [signed-by=/usr/share/keyrings/mono-archive-keyring.gpg] https://download.mono-project.com/repo/ubuntu stable-focal main" | tee /etc/apt/sources.list.d/mono-official-stable.list
-RUN rm /etc/apt/sources.list.d/microsoft-prod.list
-RUN apt update
-RUN apt install -yq apt-transport-https dotnet-sdk-8.0 nuget msbuild mono-devel
+# Microsoft .NET SDK + Mono toolchain (NuGet, msbuild). Both apt sources are
+# registered, then a single apt install + cache strip in the same layer.
+# The Mono signing key is fetched from download.mono-project.com (CI-allowlisted)
+# and dearmored, since keyserver.ubuntu.com is blocked and apt-key is deprecated.
+RUN curl -sL https://packages.microsoft.com/config/ubuntu/22.04/packages-microsoft-prod.deb -o packages-microsoft-prod.deb \
+    && dpkg -i packages-microsoft-prod.deb && rm packages-microsoft-prod.deb \
+    && curl -fsSL https://download.mono-project.com/repo/xamarin.gpg \
+         | gpg --dearmor -o /usr/share/keyrings/mono-archive-keyring.gpg \
+    && echo "deb [signed-by=/usr/share/keyrings/mono-archive-keyring.gpg] https://download.mono-project.com/repo/ubuntu stable-focal main" \
+         > /etc/apt/sources.list.d/mono-official-stable.list \
+    && rm /etc/apt/sources.list.d/microsoft-prod.list \
+    && apt-get update \
+    && apt-get install -yq --no-install-recommends \
+         dotnet-sdk-8.0 nuget msbuild mono-devel \
+    && rm -rf /var/lib/apt/lists/*
 
-# Install Java, Maven and Gradle
-RUN curl -s "https://get.sdkman.io" | bash
-RUN source "/home/frogger/.sdkman/bin/sdkman-init.sh" && sdk install java `sdk list java | grep -E "$JAVA_VERSION.*tem" | head -1 | awk '{print $NF}'` && java -version \
+# Java JDK 17 + Maven + Gradle 9.0.0 via SDKMAN. Archives are flushed and SDKMAN
+# scratch dirs removed to keep the layer small.
+RUN curl -s "https://get.sdkman.io" | bash \
+    && source "/home/frogger/.sdkman/bin/sdkman-init.sh" \
+    && sdk install java `sdk list java | grep -E "$JAVA_VERSION.*tem" | head -1 | awk '{print $NF}'` && java -version \
     && sdk install maven \
     && sdk install gradle 9.0.0 \
-    && sdk flush archives
+    && sdk flush archives \
+    && rm -rf /home/frogger/.sdkman/tmp /home/frogger/.sdkman/var/log
 
-# Install Podman
-RUN apt install -y ca-certificates
-RUN apt update
-RUN apt -yq install podman
-
-# Install Docker client
-RUN curl -fsSL https://download.docker.com/linux/ubuntu/gpg | gpg --dearmor -o /usr/share/keyrings/docker-archive-keyring.gpg
-RUN echo "deb [arch=$(dpkg --print-architecture) signed-by=/usr/share/keyrings/docker-archive-keyring.gpg] https://download.docker.com/linux/ubuntu $(lsb_release -cs) stable" | tee /etc/apt/sources.list.d/docker.list > /dev/null
-RUN apt update
-RUN apt install -y docker-ce docker-ce-cli containerd.io
-
-# Clean up
-RUN apt autoremove
-RUN apt clean
+# Podman + Docker CLI. Docker apt source uses a signed-by keyring; everything
+# installed in one layer with the apt cache stripped.
+RUN curl -fsSL https://download.docker.com/linux/ubuntu/gpg \
+         | gpg --dearmor -o /usr/share/keyrings/docker-archive-keyring.gpg \
+    && echo "deb [arch=$(dpkg --print-architecture) signed-by=/usr/share/keyrings/docker-archive-keyring.gpg] https://download.docker.com/linux/ubuntu $(lsb_release -cs) stable" \
+         > /etc/apt/sources.list.d/docker.list \
+    && apt-get update \
+    && apt-get install -yq --no-install-recommends \
+         podman docker-ce-cli containerd.io \
+    && rm -rf /var/lib/apt/lists/*


### PR DESCRIPTION
Three coordinated changes to the Dockerfile:

1. Image size reduction (Tier 1 cleanup pass)
   - 25 RUN statements coalesced to 7, grouped by domain.
   - Each apt install ends with `rm -rf /var/lib/apt/lists/*` in the same layer that created the cache, so the cache no longer persists in intermediate layers.
   - apt-get everywhere instead of apt (no "stable CLI" warnings).
   - --no-install-recommends on every install.
   - `pip install --no-cache-dir`.
   - `npm cache clean --force && rm -rf /root/.npm` after yarn install.
   - SDKMAN: also clean .sdkman/tmp and .sdkman/var/log after install.
   - Drop the trailing `apt autoremove` / `apt clean` (redundant now).
   - ca-certificates + apt-transport-https moved into prerequisites.

2. CVE remediation
   - Explicitly upgrade system pip (CVE-2025-8869, >=25.3) and setuptools (CVE-2025-47273, >=78.1.1) after pipenv/poetry install.

3. Drop the docker daemon (docker-ce) and keep only docker-ce-cli. The image is a build environment that uses the host docker socket bind-mounted in; the daemon is not run inside the container. Removes dockerd's embedded Go 1.25.x, grpc 1.78.0, buildkit, and x/net findings from the scan.